### PR TITLE
Relax PEP 517 build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,7 @@ publish = [
 
 [build-system]
 requires = [
-    "build~=0.8",
-    "setuptools~=65.0",
-    "wheel~=0.37"
+    "setuptools>=65.0"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
I noticed a couple of things when working on this package for [nixpkgs](https://github.com/NixOS/nixpkgs):

1. setuptools is already at version 68.1.2. Given how fast it iterates, would you be OK with not capping the version unless it releases a version that we find out breaks the build?

2. build is a PEP 517 build front-end (which we are using also), but it's not a requirement for setuptools to build the package (unless I am misunderstanding something)

3. wheel does not need to be listed explicitly. From the [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html):

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).