### PR TITLE
drop usage of old "toml" library

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,12 @@ sys.path.insert(0, os.path.abspath('../src'))
 
 # The name and version are retrieved from ``pyproject.toml`` in the root
 # directory.
-import toml
-with open('../pyproject.toml') as pyproject_file:
-    pyproject_data = toml.load(pyproject_file)
+try:
+   import tomllib
+except ImportError:
+   import tomli as tomllib
+with open('../pyproject.toml', 'rb') as pyproject_file:
+    pyproject_data = tomllib.load(pyproject_file)
 project = pyproject_data['project']['name']
 version = pyproject_data['project']['version']
 release = version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
     "pylint~=3.0.3",
     "sphinx~=5.3.0",
     "sphinx-rtd-theme~=1.2.0",
-    "toml~=0.10.2",
+    "tomli;python_version < '3.11'",
 ]
 publish = [
     "build~=0.8",


### PR DESCRIPTION
prefer the newer `tomli` instead
and use `tomllib` from the standard library from Python 3.11

this is the patch I used to update the Debian package

https://wiki.debian.org/Python/Backports
https://salsa.debian.org/python-team/packages/polyline/-/pipelines/898376